### PR TITLE
Enable auto localization and update timer manager

### DIFF
--- a/MahouRobo.uefnproject
+++ b/MahouRobo.uefnproject
@@ -39,9 +39,51 @@
 		{
 			"nativeCulture": "en",
 			"culturesToGenerate": [
-				"en"
+				"ar",
+				"de",
+				"en",
+				"es",
+				"es-419",
+				"fr",
+				"id",
+				"it",
+				"ja",
+				"ko",
+				"pl",
+				"pt-BR",
+				"ru",
+				"th",
+				"tr",
+				"vi",
+				"zh-Hans",
+				"zh-Hant"
 			],
 			"poFormat": "Unreal"
+		},
+		"autoLocalization":
+		{
+			"bAutoBuildLocalization": true,
+			"cultures": [
+				"ar",
+				"de",
+				"en",
+				"es",
+				"es-419",
+				"fr",
+				"id",
+				"it",
+				"ja",
+				"ko",
+				"pl",
+				"pt-BR",
+				"ru",
+				"th",
+				"tr",
+				"vi",
+				"zh-Hans",
+				"zh-Hant"
+			],
+			"mode": "Untranslated"
 		}
 	},
 	"bindings":

--- a/Plugins/MahouRobo/Content/__ExternalActors__/MahouRobo/1/HX/CSP34GOYOS1GVY6VTV0XSH.uasset
+++ b/Plugins/MahouRobo/Content/__ExternalActors__/MahouRobo/1/HX/CSP34GOYOS1GVY6VTV0XSH.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba683cb273ba6313f38c1abb9506dd191b0223483634e60017d63433e534c6ab
-size 23024
+oid sha256:a07e84589b6ac93814d03bd57bd4fd8c70a309e206e45c9bbc9c4fd831edda51
+size 24933


### PR DESCRIPTION
## Summary

- enables automatic localization builds for the configured supported cultures
- updates the placed `timer manager` Verse device actor after its UEFN re-save

## Impact

The project can generate localization data for the expanded culture list, while preserving the current level configuration for the timer manager device.

## Validation

- parsed `MahouRobo.uefnproject` successfully as JSON
- confirmed the external actor identifies as the placed `timer manager` Verse device
- verified the branch is clean after committing
